### PR TITLE
Add todo list feature

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
 </head>
 <body>
   <h1>FinBuddy</h1>
+  <p><a href="/todo.html">Go to Todo List</a></p>
   <form id="txForm">
     <label>Type
       <select id="type">

--- a/public/todo.html
+++ b/public/todo.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Todo List</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    .todo-container { max-width: 400px; margin: auto; }
+    ul { list-style: none; padding: 0; }
+    li { background: #f2f2f2; margin: .5em 0; padding: .5em; border-radius: 4px; display: flex; justify-content: space-between; align-items: center; }
+    button.delete { background: transparent; border: none; color: #f44336; cursor: pointer; font-size: 1.2em; }
+  </style>
+</head>
+<body>
+  <div class="todo-container">
+    <h1>Todo List</h1>
+    <form id="todoForm">
+      <input id="taskText" placeholder="New task" required />
+      <button type="submit">Add</button>
+    </form>
+    <ul id="taskList"></ul>
+  </div>
+  <script src="todo.js"></script>
+</body>
+</html>

--- a/public/todo.js
+++ b/public/todo.js
@@ -1,0 +1,55 @@
+async function fetchTasks() {
+  const res = await fetch('/api/tasks');
+  return res.json();
+}
+
+async function addTask(text) {
+  const res = await fetch('/api/tasks', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text })
+  });
+  return res.json();
+}
+
+async function deleteTask(id) {
+  await fetch(`/api/tasks/${id}`, { method: 'DELETE' });
+}
+
+const form = document.getElementById('todoForm');
+const list = document.getElementById('taskList');
+
+function render(tasks) {
+  list.innerHTML = '';
+  tasks.forEach(t => {
+    const li = document.createElement('li');
+    li.textContent = t.text;
+    const btn = document.createElement('button');
+    btn.textContent = '×';
+    btn.className = 'delete';
+    btn.onclick = async () => {
+      await deleteTask(t.id);
+      const updated = await fetchTasks();
+      render(updated);
+    };
+    li.appendChild(btn);
+    list.appendChild(li);
+  });
+}
+
+async function init() {
+  const tasks = await fetchTasks();
+  render(tasks);
+}
+
+form.addEventListener('submit', async e => {
+  e.preventDefault();
+  const text = document.getElementById('taskText').value.trim();
+  if (!text) return;
+  await addTask(text);
+  const tasks = await fetchTasks();
+  render(tasks);
+  form.reset();
+});
+
+init();

--- a/server.js
+++ b/server.js
@@ -11,10 +11,16 @@ app.use(express.static(path.join(__dirname, 'public')));
 // Helper to read data
 function readData() {
   if (!fs.existsSync(DATA_FILE)) {
-    fs.writeFileSync(DATA_FILE, JSON.stringify({ transactions: [] }, null, 2));
+    fs.writeFileSync(
+      DATA_FILE,
+      JSON.stringify({ transactions: [], tasks: [] }, null, 2)
+    );
   }
   const raw = fs.readFileSync(DATA_FILE);
-  return JSON.parse(raw);
+  const data = JSON.parse(raw);
+  if (!data.tasks) data.tasks = [];
+  if (!data.transactions) data.transactions = [];
+  return data;
 }
 
 function writeData(data) {
@@ -38,6 +44,30 @@ app.post('/api/transactions', (req, res) => {
   data.transactions.push(tx);
   writeData(data);
   res.json(tx);
+});
+
+app.get('/api/tasks', (req, res) => {
+  const data = readData();
+  res.json(data.tasks);
+});
+
+app.post('/api/tasks', (req, res) => {
+  const data = readData();
+  const task = {
+    id: Date.now(),
+    text: req.body.text || ''
+  };
+  data.tasks.push(task);
+  writeData(data);
+  res.json(task);
+});
+
+app.delete('/api/tasks/:id', (req, res) => {
+  const data = readData();
+  const id = Number(req.params.id);
+  data.tasks = data.tasks.filter(t => t.id !== id);
+  writeData(data);
+  res.json({ success: true });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- allow storing `tasks` in `data.json`
- add API routes to manage tasks
- link to new todo list from main page
- implement Todo List page with client-side JS

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688388ef7e808321b68d8c1ba4c0be29